### PR TITLE
feat: change Events to Actions

### DIFF
--- a/lib/src/main/java/com/ch/redukt/Action.kt
+++ b/lib/src/main/java/com/ch/redukt/Action.kt
@@ -1,4 +1,4 @@
 package com.ch.redukt
 
 
-interface Event
+interface Action

--- a/lib/src/main/java/com/ch/redukt/Dispatcher.kt
+++ b/lib/src/main/java/com/ch/redukt/Dispatcher.kt
@@ -3,7 +3,7 @@ package com.ch.redukt
 /**
  * Represents a dispatch function
  */
-typealias Dispatch = (Event) -> Unit
+typealias Dispatch = (Action) -> Unit
 
 interface Dispatcher {
   val dispatch: Dispatch

--- a/lib/src/main/java/com/ch/redukt/Reduce.kt
+++ b/lib/src/main/java/com/ch/redukt/Reduce.kt
@@ -4,4 +4,4 @@ package com.ch.redukt
  * Represents a pure function responsible for calculating state changes and
  * producing a [Store.Transition] for subscribers to consume.
  */
-typealias Reduce<StateT> = (event: Event, state: StateT) -> Transition<StateT>
+typealias Reduce<StateT> = (action: Action, state: StateT) -> Transition<StateT>

--- a/lib/src/main/java/com/ch/redukt/Store.kt
+++ b/lib/src/main/java/com/ch/redukt/Store.kt
@@ -33,9 +33,9 @@ data class Store<StateT>(
    * Receives events. Feeds each event to [reducers] and notifies
    * subscribers of new [Transition]s
    */
-  override val dispatch: Dispatch = { event: Event ->
+  override val dispatch: Dispatch = { action: Action ->
     reducers.forEach { reduce ->
-      with(reduce(event, state)) {
+      with(reduce(action, state)) {
         state = toState
         subscribers.forEach { it(this) }
       }

--- a/lib/src/test/java/com/ch/redukt/ReduktTests.kt
+++ b/lib/src/test/java/com/ch/redukt/ReduktTests.kt
@@ -3,119 +3,127 @@ package com.ch.redukt
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
-/**
- * Example local unit test, which will execute on the development machine (host).
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
-sealed class CounterEvent : Event {
-  object ResetRequested : CounterEvent()
-  object IncrementRequested : CounterEvent()
-  object DecrementRequested : CounterEvent()
-  object IncrementAsCommandRequested : CounterEvent()
+sealed class CounterAction : Action {
+  object ResetState : CounterAction()
+  object IncrementCount : CounterAction()
+  object DecrementCount : CounterAction()
+  object IncrementWithCommand : CounterAction()
 }
 
 sealed class CounterCommand : Command {
   object Increment : CounterCommand()
 }
 
-class ReduktTests : StringSpec({
+class ReduktTests : StringSpec(
+  {
 
-  data class CounterState(val count: Int = 0)
+    data class CounterState(val count: Int = 0)
 
-  fun createStore(): Store<CounterState> {
-    return Store(
-      CounterState(), mutableSetOf({ action, state ->
-        when (action) {
-          CounterEvent.IncrementRequested -> Transition(state.copy(count = state.count + 1))
-          CounterEvent.DecrementRequested -> Transition(state.copy(count = state.count - 1))
-          CounterEvent.IncrementAsCommandRequested -> Transition(
-            state,
-            CounterCommand.Increment.singletonList()
-          )
-          else -> Transition(state)
-        }
-      })
-    )
-  }
+    fun createStore(): Store<CounterState> =
+      Store(
+        CounterState(),
+        mutableSetOf(
+          { action, state ->
+            when (action) {
+              CounterAction.IncrementCount -> {
+                Transition(state.copy(count = state.count + 1))
+              }
 
-  "increment increases count by one" {
-    with(createStore()) {
-      state.count shouldBe 0
-      dispatch(CounterEvent.IncrementRequested)
-      state.count shouldBe 1
+              CounterAction.DecrementCount -> {
+                Transition(state.copy(count = state.count - 1))
+              }
+
+              CounterAction.IncrementWithCommand -> {
+                CounterCommand
+                  .Increment
+                  .singletonList()
+                  .let {
+                    Transition(state, it)
+                  }
+              }
+
+              else -> Transition(state)
+            }
+          })
+      )
+
+    "increment increases count by one" {
+      with(createStore()) {
+        state.count shouldBe 0
+        dispatch(CounterAction.IncrementCount)
+        state.count shouldBe 1
+      }
     }
-  }
 
-  "side effect should increment count by one" {
-    var commandReceived = false
-    with(createStore()) {
-      subscribe {
-        it.commands.forEach { command ->
-          when (command) {
-            CounterCommand.Increment -> {
-              commandReceived = true
-              dispatch(CounterEvent.IncrementRequested)
+    "side effect should increment count by one" {
+      var commandReceived = false
+      with(createStore()) {
+        subscribe {
+          it.commands.forEach { command ->
+            when (command) {
+              CounterCommand.Increment -> {
+                commandReceived = true
+                dispatch(CounterAction.IncrementCount)
+              }
             }
           }
         }
+
+        state.count shouldBe 0
+        dispatch(CounterAction.IncrementCount)
+        state.count shouldBe 1
+        dispatch(CounterAction.IncrementWithCommand)
+        state.count shouldBe 2
+        commandReceived shouldBe true
       }
-
-      state.count shouldBe 0
-      dispatch(CounterEvent.IncrementRequested)
-      state.count shouldBe 1
-      dispatch(CounterEvent.IncrementAsCommandRequested)
-      state.count shouldBe 2
-      commandReceived shouldBe true
     }
-  }
 
-  "can add and remove reducer to change behavior" {
-    with(createStore()) {
-      val resetReducer: Reduce<CounterState> = { event, state ->
-        when (event) {
-          is CounterEvent.ResetRequested -> Transition(state.copy(count = 0))
-          else -> Transition(state)
+    "can add and remove reducer to change behavior" {
+      with(createStore()) {
+        val resetReducer: Reduce<CounterState> = { event, state ->
+          when (event) {
+            is CounterAction.ResetState -> Transition(state.copy(count = 0))
+            else -> Transition(state)
+          }
         }
+
+        removeReducer(resetReducer) shouldBe false
+        state.count shouldBe 0
+        dispatch(CounterAction.IncrementCount)
+        state.count shouldBe 1
+        dispatch(CounterAction.ResetState)
+        state.count shouldBe 1
+        addReducer(resetReducer) shouldBe true
+        dispatch(CounterAction.ResetState)
+        state.count shouldBe 0
+        dispatch(CounterAction.IncrementCount)
+        state.count shouldBe 1
+        removeReducer(resetReducer) shouldBe true
+        dispatch(CounterAction.ResetState)
+        state.count shouldBe 1
+        removeReducer(resetReducer) shouldBe false
       }
-
-      removeReducer(resetReducer) shouldBe false
-      state.count shouldBe 0
-      dispatch(CounterEvent.IncrementRequested)
-      state.count shouldBe 1
-      dispatch(CounterEvent.ResetRequested)
-      state.count shouldBe 1
-      addReducer(resetReducer) shouldBe true
-      dispatch(CounterEvent.ResetRequested)
-      state.count shouldBe 0
-      dispatch(CounterEvent.IncrementRequested)
-      state.count shouldBe 1
-      removeReducer(resetReducer) shouldBe true
-      dispatch(CounterEvent.ResetRequested)
-      state.count shouldBe 1
-      removeReducer(resetReducer) shouldBe false
     }
-  }
 
-  "temporal reducer" {
-    with(createStore()) {
-      val resetReducer: Reduce<CounterState> = { event, state ->
-        when (event) {
-          is CounterEvent.ResetRequested -> Transition(state.copy(count = 0))
-          else -> Transition(state)
+    "temporal reducer" {
+      with(createStore()) {
+        val resetReducer: Reduce<CounterState> = { event, state ->
+          when (event) {
+            is CounterAction.ResetState -> Transition(state.copy(count = 0))
+            else -> Transition(state)
+          }
         }
-      }
 
-      addReducer(TemporalReducer(resetReducer, state))
-      state.count shouldBe 0
-      dispatch(CounterEvent.IncrementRequested)
-      state.count shouldBe 1
-      dispatch(CounterEvent.ResetRequested)
-      state.count shouldBe 0
-      dispatch(TemporalEvent.Undo)
-      state.count shouldBe 1
-      dispatch(TemporalEvent.Redo)
-      state.count shouldBe 0
+        addReducer(TemporalReducer(resetReducer, state))
+        state.count shouldBe 0
+        dispatch(CounterAction.IncrementCount)
+        state.count shouldBe 1
+        dispatch(CounterAction.ResetState)
+        state.count shouldBe 0
+        dispatch(TemporalAction.Undo)
+        state.count shouldBe 1
+        dispatch(TemporalAction.Redo)
+        state.count shouldBe 0
+      }
     }
-  }
-})
+  })


### PR DESCRIPTION
Changes Events to Actions in order to keep Presentation-specific events from leaking into the Domain